### PR TITLE
Modern refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # smbc-scraper
-Scrape [Saturday Morning Breakfast Cereal comics](https://www.smbc-comics.com/) (cartoons + title text). Scraper uses the Beautiful Soup 4 library.
+Scrape [Saturday Morning Breakfast Cereal comics](https://www.smbc-comics.com/) (cartoons, aftercomics, title text, URL). Scraper uses the Beautiful Soup 4 library.
 
 To run, install [Python 3.x](https://www.python.org/downloads/) and [bs4](https://pypi.org/project/beautifulsoup4/). Then hit: `python3 smbc-scraper.py`
 
-A new directory is created for each page where the cartoons are stored in the original format (PNG for the more recent comics and GIF for older ones) and the titles are stored in a text file. Everything is stored in the current directory from which the script is invoked.
+A new directory is created for each page where the cartoons and aftercomics are stored in the original format, and the URLs and titles are stored in text files. Everything is stored in the `comics` directory created where the script is invoked.
 
-As of this writing, the server doesn't block automated requests. If you get blocked, try increasing the random delay range in line 91. Else, you'll need to resort to some IP rotation.
+As of this writing, the server doesn't block automated requests. If you get blocked, try increasing the random delay range in line 135. Else, you'll need to resort to some IP rotation.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+bs4
+requests
+lxml

--- a/smbc-scraper.py
+++ b/smbc-scraper.py
@@ -15,80 +15,115 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-import os
-from bs4 import BeautifulSoup
-import urllib
-import requests
-import shutil
-import random
-import time
+from os import makedirs
+from bs4 import BeautifulSoup, Tag
+from urllib.request import urlopen
+from urllib.parse import quote, urlsplit, urlunsplit
+from requests import get as requests_get
+from shutil import copyfileobj
+from random import randrange
+from time import sleep
 
-print("Sunday Morning Breakfast Cereal Scraper (smbc-comics.com) V0.1")
-print("***")
-print("If you enjoy Zach Weinersmith's work, please consider supporting him on Patreon. https://www.patreon.com/ZachWeinersmith?ty=h
-print("Alternatively, buy some SMBC merchandise: https://hivemill.com/collections/smbc")
-print("Pretty please with sugar on top. Patronage is what helps artists continue doing what they do best. Thank you!")
-print("***")
-print("Initializing...")
 
-# Hard-coding the initial URL
-first_url = 'https://www.smbc-comics.com/comic/2002-09-05'
-current_url = first_url
-next_url = first_url
-page_request = requests.get( first_url )
-parent_directory = os.getcwd()
-i = 1
+DIRECTORY: str = 'comics'
+EXTENSIONS: set = {'png', 'gif', 'jpg', 'jpeg',}
+def parse_img(element: Tag, stem: str):
+    url: str = element['src']
+    print("Downloading image from", url)
+    # SMBC uses different image formats
+    ext: str = url.split('.')[-1]
+    if ext not in EXTENSIONS:
+        print("Not a recognized image format!")
+        return
+
+    with urlopen(url) as response, \
+         open(f'{stem}.{ext}', 'wb') as f:
+            copyfileobj(response, f)
+
+
+# Random user agent to calm down any anti-bot measures
+headers = {
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
+    }
+def request(url):
+    return requests_get(url, headers=headers)
+
+
+print("""
+Sunday Morning Breakfast Cereal Scraper (smbc-comics.com) V0.2
+***
+If you enjoy Zach Weinersmith's work, please consider supporting him on Patreon. https://www.patreon.com/ZachWeinersmith?ty
+Alternatively, buy some SMBC merchandise: https://hivemill.com/collections/smbc
+Pretty please with sugar on top. Patronage is what helps artists continue doing what they do best. Thank you!
+***
+Initializing...
+""")
+
+
+i: int
+try:
+    with open('history.txt', 'r') as f:
+        i = int(f.readline())
+        current_url = f.readline().strip()
+except FileNotFoundError:
+    print("No history file found. Starting from the beginning.")
+    i = 1
+    current_url = 'https://www.smbc-comics.com/comic/2002-09-05'
+
 
 # While page exists, proceed
-while( page_request.status_code != 404 ):
+while True:
+    print("Processing comic number", i)
+    id: str = str(i).zfill(4)
+    stem: str = f'{DIRECTORY}/{id}'
+    makedirs(stem, exist_ok=True)
 
-	if next_url == 'https://www.smbc-comics.com/comic/2002-09-05':
-		current_page = requests.get( first_url )
-	else:
-		current_page = requests.get( next_url )
-	# Grab content of current page
-	html_content = current_page.text
-	soup = BeautifulSoup( html_content,'lxml' )
-	# Retrieving title text of the image. Use web developer tools to inspect the DOM.
-	title_text = soup.find( 'div', {'id':'cc-comicbody'} ).img['title'].encode('ascii','ignore').decode()
-	# Retrieving URL of the comic image
-	comic_image_url = soup.find( 'div',{'id':'cc-comicbody'} ).img['src']	
-	print("...")
-	print("Processing comic number ", i)
-	print("Image URL is: ", comic_image_url)
+    # Request current page
+    page = request(current_url)
+    if page.status_code != 200:
+        print(f"HTTP error encountered: {page.status_code}. Exiting...")
+        break
 
-	# Numbering the directories
-	comic_directory = str( i )
-	os.mkdir( comic_directory )
-	i = i + 1
-	os.chdir( comic_directory )
-	directory = os.getcwd()
-	# DEBUG LOG	print("Current directory is: ", directory )
-	
-	title_text_file = open( comic_directory + '.txt', 'w' )
-	title_text_file.write( title_text )
-	title_text_file.close()
-	# DEBUG LOG	print("Title text successfully written")
-	
-	# SMBC uses different image formats
-	if ( "png" in comic_image_url ):
-	# urllib.request.urlretrieve is considered deprecated https://docs.python.org/3/library/urllib.request.html#legacy-interface
-	# Using urlopen instead
-		with urllib.request.urlopen( comic_image_url ) as response, open( ( comic_directory + '.png'), 'wb') as out_file:
-		    shutil.copyfileobj(response, out_file)
-	elif ( "gif" in comic_image_url ):
-	# urllib.request.urlretrieve is considered deprecated https://docs.python.org/3/library/urllib.request.html#legacy-interface
-	# Using urlopen instead
-		with urllib.request.urlopen( comic_image_url ) as response, open( ( comic_directory + '.gif'), 'wb') as out_file:
-		    shutil.copyfileobj(response, out_file)
-	else:
-		print("Not a recognized image format!")
-	
-	next_url = soup.find('a',{'class':'cc-next'})['href']	
-	os.chdir( parent_directory )
-	
-	# Basic pseudo-random wait to avoid detection by the target server. Change the range of values to go faster
-	delay = random.randrange(3, 30)
-	print("Comic number successfully scraped.")
-	print("Waiting for ", delay, "seconds between requests to throw off anti-bot mitigation measures...")
-	time.sleep( delay )
+    with open(f'{stem}/url.txt', 'w') as f:
+        f.write(current_url)
+
+    # Grab content of current page
+    soup = BeautifulSoup(page.text, 'lxml')
+
+    # Retrieving title text
+    comic_image_element: Tag = soup.find(
+        'div', {'id': 'cc-comicbody'}).img
+    title: str = comic_image_element['title'].encode('ascii', 'ignore').decode()
+
+    with open(f'{stem}/title.txt', 'w') as f:
+        f.write(title)
+
+    # Retrieve main comic image
+    parse_img(comic_image_element, f'{stem}/comic')
+
+    # Check for aftercomic (red button) image
+    try:
+        aftercomic_image_element: Tag = soup.find(
+            'div', {'id': 'aftercomic'}).img
+        parse_img(aftercomic_image_element, f'{stem}/aftercomic')
+    except AttributeError:
+        print("No aftercomic image found!")
+
+    # Check for next comic URL
+    next_element: Tag = soup.find(
+        'a', {'class': 'cc-next'})
+    if not next_element:
+        print("No more comics found. Exiting...")
+        break
+
+    # Move on to next comic
+    i += 1
+    current_url = next_element['href']
+    with open('history.txt', 'w') as f:
+        f.write(f'{i}\n{current_url}')
+
+    # Basic pseudo-random wait to avoid detection by the target server. Change the range of values to go faster
+    print("Comic successfully scraped.")
+    print("Waiting for ", delay := randrange(6, 60),
+          "seconds between requests to throw off anti-bot mitigation measures...")
+    sleep(delay)

--- a/smbc-scraper.py
+++ b/smbc-scraper.py
@@ -36,6 +36,14 @@ def parse_img(element: Tag, stem: str):
         print("Not a recognized image format!")
         return
 
+    # URL-encode the URL path to avoid issues with special characters,
+    # including a space (ref. https://www.smbc-comics.com/comic/a-monster-2),
+    # in image names. Encoding the whole thing would break scheme.
+    url_split = urlsplit(url)
+    url = urlunsplit(url_split._replace(
+        path=quote(url_split.path)
+        ))
+
     with urlopen(url) as response, \
          open(f'{stem}.{ext}', 'wb') as f:
             copyfileobj(response, f)


### PR DESCRIPTION
- bugfix: fails on jpegs (e.g. https://www.smbc-comics.com/comic/2012-01-16)
- bugfix: unprocessable special characters in img src
- feature: resuming via history file
- feature: url, aftercomic saving
- reusable function `parse_img()` for image elements
- doubled wait
- granular imports
- main loop refactor
- added requirements.txt
- tested on the entire publication on Python 3.8, 3.9, 3.11, 3.12